### PR TITLE
일반 로그인 추가 및 세션 변경

### DIFF
--- a/components/chat/renderMessage.tsx
+++ b/components/chat/renderMessage.tsx
@@ -34,7 +34,7 @@ const MessageContainer: React.FC<{ messages: RoomMessageDto[]; userlist: Partici
   }, [messages]);
 
   const handleFindUser = (userId: number) => {
-    if (userId == session?.user.user_id) {
+    if (userId == session?.user.id) {
       return false;
     }
 
@@ -66,7 +66,7 @@ const MessageContainer: React.FC<{ messages: RoomMessageDto[]; userlist: Partici
       {messages.map((message, index) => (
         <Frame key={index}>
           {handleFindUser(message.senderId) && (
-            <UserFrame senderId={message.senderId} currentUser={session?.user.user_id}>
+            <UserFrame senderId={message.senderId} currentUser={session?.user.id}>
               <UserImage
                 src={handleSetUserAvatar(message.senderId)}
                 alt="Profle Image"
@@ -77,9 +77,9 @@ const MessageContainer: React.FC<{ messages: RoomMessageDto[]; userlist: Partici
             </UserFrame>
           )}
 
-          <MessageFrame senderId={message.senderId} currentUser={session?.user.user_id}>
+          <MessageFrame senderId={message.senderId} currentUser={session?.user.id}>
             {message.senderId != 0 && (
-              <Message key={index} senderId={message.senderId} currentUser={session?.user.user_id}>
+              <Message key={index} senderId={message.senderId} currentUser={session?.user.id}>
                 {message.text}
               </Message>
             )}

--- a/components/chat/userListModal.tsx
+++ b/components/chat/userListModal.tsx
@@ -46,7 +46,7 @@ const userListModal: React.FC<{
   const overlayTop = `${createButtonRect.top + createButtonRect.height * 1.5}px`;
 
   useEffect(() => {
-    const userId = session?.user.user_id;
+    const userId = session?.user.id;
     const user = userlist.find((user) => user.id === userId);
     if (user && user.grade == 2) {
       setIsOwner(true);

--- a/components/join/preview.tsx
+++ b/components/join/preview.tsx
@@ -63,7 +63,7 @@ const PreviewContainer: React.FC<{
               <NicknameText> NickName </NicknameText>
             )}
           </NicknameFrame>
-          {session ? <IntraText> {session.user.login} </IntraText> : null}
+          {session ? <IntraText> {session.user.intraName} </IntraText> : null}
         </NameFrame>
         <DivisionBar />
         {!checknick ? (

--- a/components/nevigation.tsx
+++ b/components/nevigation.tsx
@@ -11,7 +11,7 @@ const Navigation = () => {
         {session ? (
           <>
             {/* <Text> Sign in as {session.user.email} </Text> <br /> */}
-            <Text> Sign in as {session?.user?.login} </Text> <br />
+            <Text> Sign in as {session?.user?.intraName} </Text> <br />
             {/* <Text> accessToken : {session.accessToken} </Text> <br /> */}
             <button onClick={() => signOut()}>Sign out</button>
           </>

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -40,9 +40,6 @@ export const authOptions: NextAuthOptions = {
               response.headers['set-cookie']?.[0]?.match(/refreshToken=([^;]+)/)?.[1];
             return {
               id: response.data.id,
-              name: response.data.nickName, // Assuming 'name' is required by NextAuth's User type
-              email: response.data.email, // Include this if 'email' is a required field in User type
-              image: response.data.avatar, //
               nickName: response.data.nickName,
               intraName: response.data.intraName,
               avatar: response.data.avatar,

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -33,7 +33,6 @@ export const authOptions: NextAuthOptions = {
             intraName: credentials.intraname,
             password: credentials.password,
           });
-          console.log(response);
           if (response.status === 200) {
             const accessToken = response.headers.authorization.replace('Bearer ', '');
             const refreshToken =
@@ -59,13 +58,18 @@ export const authOptions: NextAuthOptions = {
   callbacks: {
     // @ts-ignore
     async signIn({ profile, user }) {
-      console.log('signIn : ', user);
       if (!profile && !user) return false;
       if (!profile && user) return user;
       if (invalidPrimaryCampus(profile)) return false;
       return user;
     },
-    async jwt({ user, token, profile, account }) {
+    async jwt({ user, token, profile, account, trigger, session }) {
+      if (trigger == 'update') {
+        return {
+          ...token,
+          ...session.user,
+        };
+      }
       if (!profile && account?.type == 'credentials') {
         token.id = user.id;
         token.nickName = user.nickName;
@@ -98,7 +102,6 @@ export const authOptions: NextAuthOptions = {
       return token;
     },
     async session({ session, token }) {
-      console.log('session : ', session, token);
       session.user.id = token.id as number;
       session.user.nickName = token.nickName as string;
       session.user.intraName = token.intraName as string;
@@ -106,6 +109,7 @@ export const authOptions: NextAuthOptions = {
       session.accessToken = token.accessToken as string;
       session.refreshToken = token.refreshToken as string;
       session.responseCode = token.responseCode as number;
+      console.log(session);
       return session;
     },
   },

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -26,6 +26,7 @@ export const authOptions: NextAuthOptions = {
         password: { label: 'Password', type: 'password' },
       },
       authorize: async (credentials) => {
+        if (!credentials) return null;
         try {
           const apiUrl = 'http://localhost:8080/auth/signIn';
           const response = await axios.post(apiUrl, {
@@ -33,20 +34,22 @@ export const authOptions: NextAuthOptions = {
             password: credentials.password,
           });
           console.log(response);
-          if (response.status === 201) {
-            // 200으로 바꿔야함
+          if (response.status === 200) {
             const accessToken = response.headers.authorization.replace('Bearer ', '');
             const refreshToken =
               response.headers['set-cookie']?.[0]?.match(/refreshToken=([^;]+)/)?.[1];
             return {
               id: response.data.id,
+              name: response.data.nickName, // Assuming 'name' is required by NextAuth's User type
+              email: response.data.email, // Include this if 'email' is a required field in User type
+              image: response.data.avatar, //
               nickName: response.data.nickName,
               intraName: response.data.intraName,
               avatar: response.data.avatar,
               responseCode: response.status,
               accessToken,
               refreshToken,
-            };
+            } as any;
           }
         } catch (e) {
           console.error('Sign in error:', e);

--- a/pages/chat/[roomId].tsx
+++ b/pages/chat/[roomId].tsx
@@ -103,7 +103,7 @@ const Chat = () => {
 
       const handleRoomKick = (response: ActionRoomData) => {
         const { targetId } = response;
-        const userId = session?.user.user_id;
+        const userId = session?.user.id;
         const targetUser = userlist.find((user) => user.id === targetId);
         if (targetUser) {
           if (targetId == userId) {
@@ -116,7 +116,7 @@ const Chat = () => {
 
       const handleRoomBan = (response: ActionRoomData) => {
         const { targetId } = response;
-        const userId = session?.user.user_id;
+        const userId = session?.user.id;
         const targetUser = userlist.find((user) => user.id === targetId);
         if (targetUser) {
           if (targetId == userId) {
@@ -136,7 +136,7 @@ const Chat = () => {
 
       const handleRoomMute = (response: ActionRoomData) => {
         const { targetId } = response;
-        const userId = session?.user.user_id;
+        const userId = session?.user.id;
         const targetUser = userlist.find((user) => user.id === targetId);
         if (targetUser) {
           if (targetId == userId) {
@@ -251,7 +251,7 @@ const Chat = () => {
         .emitWithAck('room-message', {
           text: messageText,
           roomId: roomId,
-          senderId: session?.user.user_id,
+          senderId: session?.user.id,
         })
         .then((response) => {
           console.log(response);

--- a/pages/chat/[roomId].tsx
+++ b/pages/chat/[roomId].tsx
@@ -73,7 +73,8 @@ const Chat = () => {
 
       const handleRoomMessage = (response: RoomMessageDto) => {
         const text = response.text;
-        console.log('response.text : ' + text);
+        console.log('room-message response : ' + response.senderId);
+        console.log('room-message response : ' + response.text);
         setMessages((prevMessages) => [...prevMessages, response]);
       };
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,9 +14,12 @@ const Home: NextPage = () => {
       {/* 테스트용 */}
       {session ? (
         <>
-          Sign in as {session.user.email} <br />
-          Sign in as {session.user.login} <br />
+          Sign in id : {session.user.id} <br />
+          nickName : {session.user.nickName} <br />
+          intraName : {session.user.intraName} <br />
+          avatar : {session.user.avatar} <br />
           accessToken : {session.accessToken} <br />
+          refreshToken : {session.refreshToken} <br />
           responseCode : {session.responseCode} <br />
           <button onClick={() => signOut()}>Sign out</button>
         </>

--- a/pages/join/index.tsx
+++ b/pages/join/index.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
+import { useSession } from 'next-auth/react';
 import Container from '../../components/rowLayout';
 import InfoContainer from '../../components/join/info';
 import PreviewContainer from '../../components/join/preview';
@@ -13,6 +14,7 @@ const JoinPage: React.FC = () => {
   const [profilePath, setProfilePath] = useState('profile2.png');
   const [uploadedImage, setUploadedImage] = useState<File | null>(null);
   const router = useRouter();
+  const { data: session, update } = useSession();
 
   const handleNicknameChange = (newNickname: string) => {
     setNickname(newNickname);
@@ -59,18 +61,30 @@ const JoinPage: React.FC = () => {
   };
 
   const handleComplete = async (newNickname: string, profile: number) => {
+    let response;
     try {
       if (profile === 0) {
         if (uploadedImage) {
           const formData = new FormData();
           formData.append('avatar', uploadedImage);
           formData.append('nickName', newNickname);
-          await axiosInstance.patch('/users/profile', formData);
+          response = await axiosInstance.patch('/users/profile', formData);
         }
       } else {
-        const response = await axiosInstance.patch('/users/profileWithUrl', {
+        response = await axiosInstance.patch('/users/profileWithUrl', {
           nickName: newNickname,
           avatar: profilePath,
+        });
+      }
+      if (response) {
+        console.log(response);
+        await update({
+          ...session,
+          user: {
+            ...session?.user,
+            nickName: response.data.nickName,
+            avatar: response.data.filepath,
+          },
         });
       }
       router.push('http://localhost:3000/');

--- a/pages/login/choice.tsx
+++ b/pages/login/choice.tsx
@@ -23,11 +23,6 @@ const ChoicePage: React.FC = () => {
     }
   });
 
-  const handleCommonLogin = async () => {
-    // 일반로그인
-    // router.push("http://localhost:3000/");
-  };
-
   return (
     <>
       <Container>
@@ -35,7 +30,7 @@ const ChoicePage: React.FC = () => {
         <LoginButton onClick={() => signIn('42-school')}>
           <LoginButtonImg src={FTLoginButton} alt="42 Login" />
         </LoginButton>
-        <LoginButton onClick={handleCommonLogin}>
+        <LoginButton onClick={() => signIn('Credentials')}>
           <LoginButtonImg src={CommonLoginButton} alt="Common Login" />
         </LoginButton>
       </Container>

--- a/pages/mypage/components/paging.tsx
+++ b/pages/mypage/components/paging.tsx
@@ -57,7 +57,7 @@ const Paging = () => {
 
   const handleAchieveList = async () => {
     try {
-      const userId = session?.user.user_id;
+      const userId = session?.user.id;
       const response = await axiosInstance.get("/users/detail", {
         params: { id: userId },
       });

--- a/pages/mypage/components/user.tsx
+++ b/pages/mypage/components/user.tsx
@@ -1,10 +1,10 @@
-import styled from "styled-components";
-import Image from "next/image";
-import { useState, useEffect } from "react";
-import { useSession } from "next-auth/react";
-import { profile12 } from "./profile";
-import { bronze, silver, gold, platinum, diamond } from "./tier";
-import info from "../../../public/Icon/info.png";
+import styled from 'styled-components';
+import Image from 'next/image';
+import { useState, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+import { profile12 } from './profile';
+import { bronze, silver, gold, platinum, diamond } from './tier';
+import info from '../../../public/Icon/info.png';
 
 const UserContainer: React.FC<{
   nickname: string;
@@ -15,10 +15,10 @@ const UserContainer: React.FC<{
   avatar: string;
 }> = ({ nickname, tierIndex, totalGames, totalWins, winRate, avatar }) => {
   const { data: session } = useSession();
-  // console.log(session.user.user_id);
+  // console.log(session.user.id);
 
   const tierImages = [bronze, silver, gold, platinum, diamond];
-  const tierTexts = ["브론즈", "실버", "골드", "플래티넘", "다이아몬드"];
+  const tierTexts = ['브론즈', '실버', '골드', '플래티넘', '다이아몬드'];
 
   return (
     <UserProfile>
@@ -36,12 +36,7 @@ const UserContainer: React.FC<{
       <DivisionBar />
       <TierFrame>
         {session ? (
-          <TierImage
-            src={tierImages[tierIndex]}
-            alt="Tier Image"
-            width={30}
-            height={30}
-          />
+          <TierImage src={tierImages[tierIndex]} alt="Tier Image" width={30} height={30} />
         ) : (
           <TierImage src={tierImages[tierIndex]} alt="default Image" />
         )}
@@ -106,7 +101,7 @@ const NicknameFrame = styled.div`
 
 const NicknameText = styled.div`
   color: ${(props) => props.theme.colors.white};
-  font-family: "GiantsLight";
+  font-family: 'GiantsLight';
   text-align: center;
   font-size: x-large;
 `;
@@ -114,7 +109,7 @@ const NicknameText = styled.div`
 const IntraText = styled.div`
   padding: 3%;
   color: ${(props) => props.theme.colors.brown};
-  font-family: "GiantsLight";
+  font-family: 'GiantsLight';
   text-align: center;
   font-size: large;
 `;
@@ -142,7 +137,7 @@ const TierImage = styled(Image)`
 const TierText = styled.div`
   color: ${(props) => props.theme.colors.brown};
   width: 60%;
-  font-family: "GiantsLight";
+  font-family: 'GiantsLight';
   vertical-align: middle;
   text-align: center;
   font-size: large;
@@ -170,7 +165,7 @@ const MatchStatText = styled.div`
   color: ${(props) => props.theme.colors.brown};
   width: 90%;
   height: auto;
-  font-family: "GiantsLight";
+  font-family: 'GiantsLight';
   display: flex;
   flex-direction: row;
   font-size: large;

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -31,7 +31,7 @@ const MyPage = () => {
 
   const getUserInfo = async () => {
     try {
-      const userId = session?.user.user_id;
+      const userId = session?.user.id;
       const response = await axiosInstance.get("/users/detail", {
         params: { id: userId },
       });
@@ -48,7 +48,7 @@ const MyPage = () => {
     }
 
     try {
-      const userId = session?.user.user_id;
+      const userId = session?.user.id;
       const response = await axiosInstance.get("/games/general/" + userId);
       console.log("getUserInfo() response");
       console.log(response);

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -3,11 +3,13 @@ import NextAuth from 'next-auth';
 declare module 'next-auth' {
   interface Session {
     accessToken: string;
+    refreshToken: string;
     responseCode: number;
     user: {
-      login: string;
-      email: string;
-      user_id: number;
+      id: number;
+      nickName: string;
+      intraName: string;
+      avatar: string;
     };
   }
 }

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -23,15 +23,3 @@ declare module 'next-auth' {
     refreshToken: string;
   }
 }
-
-// declare module 'next-auth' {
-//   interface User extends DefaultUser {
-//     id: number;
-//     nickName: string;
-//     intraName: string;
-//     avatar: string;
-//     responseCode: number;
-//     accessToken: string;
-//     refreshToken: string;
-//   }
-// }

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,4 +1,5 @@
 import NextAuth from 'next-auth';
+import { DefaultUser } from 'next-auth';
 
 declare module 'next-auth' {
   interface Session {
@@ -12,4 +13,25 @@ declare module 'next-auth' {
       avatar: string;
     };
   }
+  interface User extends DefaultUser {
+    id: number;
+    nickName: string;
+    intraName: string;
+    avatar: string;
+    responseCode: number;
+    accessToken: string;
+    refreshToken: string;
+  }
 }
+
+// declare module 'next-auth' {
+//   interface User extends DefaultUser {
+//     id: number;
+//     nickName: string;
+//     intraName: string;
+//     avatar: string;
+//     responseCode: number;
+//     accessToken: string;
+//     refreshToken: string;
+//   }
+// }


### PR DESCRIPTION
## CredentialsProvider 추가
로그인 선택 페이지에서 42-seoul-Login 아래 Login으로 접근 가능
현재는 next-auth 제공 로그인 페이지를 사용 중
이후에 커스텀 로그인 페이지로 변경 예정

## Session 인터페이스 수정 및 트리거 생성
- next-auth.d.ts
  - Session 인터페이스 -> users/me 양식으로 변경
  - session관련 코드의 변수명 전부 변경 (user_id -> id)
- [...nextauth].ts
  - /join 등, 닉네임과 프로필 변경시 update trigger 발생
  - 기존 세션에 변경사항 업데이트 하도록 적용